### PR TITLE
Fix login

### DIFF
--- a/install.go
+++ b/install.go
@@ -112,10 +112,21 @@ func askCredentials() (token string, err error) {
 	}
 	pass = string(bytePassword)
 
-	auth := auth.New()
-	auth.ClientID = "connector"
-	auth.Scopes = "iot:devices"
-	tok, err := auth.Token(user, pass)
+	authClient := auth.New()
+	authClient.ClientID = "connector"
+	authClient.Scopes = "iot:devices"
+
+	var tok *auth.Token
+	// Handle captcha
+	for {
+		tok, err = authClient.Token(user, pass)
+		if err == nil || !strings.HasPrefix(err.Error(), "authenticate: CAPTCHA") {
+			break
+		}
+		fmt.Println("The authentication requested a captcha! We can't let you solve it in a terminal, so please visit https://auth.arduino.cc/login. When you managed to log in from the browser come back here and press [Enter]")
+		var temp string
+		fmt.Scanln(&temp)
+	}
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Fix #19 

If the user fails the login too many times a captcha is provided, but we can't solve it in the console, so we ask the user to login on auth.arduino.cc