### PR TITLE
Fix logins by using the right CSRF cookie

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -199,8 +199,9 @@ func (c *Config) authenticate(client *http.Client, cookies cookies, uri, user, p
 	// Find csrf
 	csrf := ""
 	for _, cookie := range cookies["auth"] {
-		if cookie.Name == "_csrf" {
+		if cookie.Name == "_csrf" && cookie.Value != "" {
 			csrf = cookie.Value
+			break;
 		}
 	}
 	query := url.Values{}

--- a/install.go
+++ b/install.go
@@ -40,7 +40,7 @@ import (
 
 	"golang.org/x/crypto/ssh/terminal"
 
-	"github.com/bcmi-labs/arduino-connector/auth"
+	"github.com/arduino/arduino-connector/auth"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/facchinm/service"
 	"github.com/kardianos/osext"


### PR DESCRIPTION
Additionally, fix an outdated import path related to the migration from bcmi-labs to arduino.