### PR TITLE
Change permissions arduino-connector.cfg

### DIFF
--- a/arduino-connector-arm.sh
+++ b/arduino-connector-arm.sh
@@ -65,13 +65,6 @@ else
 	echo $password | sudo -kS -E ./arduino-connector -register -install > arduino-connector.log 2>&1
 fi
 
-if [ "$password" == "" ]
-then
-	sudo chown $USER arduino-connector.cfg
-else
-	echo $password | sudo -kS chown $USER arduino-connector.cfg
-fi
-
 
 echo start connector service
 echo ---------

--- a/arduino-connector.sh
+++ b/arduino-connector.sh
@@ -82,13 +82,6 @@ else
 	echo $password | sudo -kS -E ./arduino-connector -register -install > arduino-connector.log 2>&1
 fi
 
-if [ "$password" == "" ]
-then
-	sudo chown $USER arduino-connector.cfg
-else
-	echo $password | sudo -kS chown $USER arduino-connector.cfg
-fi
-
 
 echo start connector service
 echo ---------


### PR DESCRIPTION
Files and directories (e.g. key and pem files, sketches directory) have root permissions, but arduino-connector.cfg has $USER permissions. This file is used by Arduino Connector as root during the startup via systemd. It is better if a normal user cannot edit the config file.