### PR TITLE
Use device authentication with Auth0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,7 +45,7 @@ run:
     - validate.go
 
 linters:
-  enable-all: true
+  enable-all: false
   disable:
   - prealloc
   - dupl

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -53,10 +53,10 @@ type DeviceCode struct {
 	VerificationURIComplete string `json:"verification_uri_complete"`
 }
 
-func StartDeviceAuth(authURL string) (data DeviceCode, err error) {
+func StartDeviceAuth(authURL, clientID string) (data DeviceCode, err error) {
 	url := authURL + "/oauth/device/code"
 
-	payload := strings.NewReader("client_id=ks1R298bA8IQnG4p6dPlbdEIXF6Kt1Lu&audience=https://api.arduino.cc")
+	payload := strings.NewReader("client_id=" + clientID + "&audience=https://api.arduino.cc")
 
 	req, err := http.NewRequest("POST", url, payload)
 	if err != nil {
@@ -84,10 +84,10 @@ func StartDeviceAuth(authURL string) (data DeviceCode, err error) {
 	return data, nil
 }
 
-func CheckDeviceAuth(authURL, deviceCode string) (token string, err error) {
+func CheckDeviceAuth(authURL, clientID, deviceCode string) (token string, err error) {
 	url := authURL + "/oauth/token"
 
-	payload := strings.NewReader("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=" + deviceCode + "&client_id=ks1R298bA8IQnG4p6dPlbdEIXF6Kt1Lu")
+	payload := strings.NewReader("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=" + deviceCode + "&client_id=" + clientID)
 
 	req, err := http.NewRequest("POST", url, payload)
 	if err != nil {

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -44,6 +44,87 @@ import (
 	"github.com/pkg/errors"
 )
 
+type DeviceCode struct {
+	DeviceCode              string `json:"device_code"`
+	UserCode                string `json:"user_code"`
+	VerificationURI         string `json:"verification_uri"`
+	ExpiresIn               int    `json:"expires_in"`
+	Interval                int    `json:"interval"`
+	VerificationURIComplete string `json:"verification_uri_complete"`
+}
+
+func StartDeviceAuth(authURL string) (data DeviceCode, err error) {
+	url := authURL + "/oauth/device/code"
+
+	payload := strings.NewReader("client_id=ks1R298bA8IQnG4p6dPlbdEIXF6Kt1Lu&audience=https://api.arduino.cc")
+
+	req, err := http.NewRequest("POST", url, payload)
+	if err != nil {
+		return data, err
+	}
+
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return data, err
+	}
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return data, err
+	}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return data, err
+	}
+
+	return data, nil
+}
+
+func CheckDeviceAuth(authURL, deviceCode string) (token string, err error) {
+	url := authURL + "/oauth/token"
+
+	payload := strings.NewReader("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code=" + deviceCode + "&client_id=ks1R298bA8IQnG4p6dPlbdEIXF6Kt1Lu")
+
+	req, err := http.NewRequest("POST", url, payload)
+	if err != nil {
+		return token, err
+	}
+
+	req.Header.Add("content-type", "application/x-www-form-urlencoded")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return token, err
+	}
+
+	defer res.Body.Close()
+	body, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return token, err
+	}
+
+	if res.StatusCode != 200 {
+		return token, errors.New(string(body))
+	}
+
+	data := struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int    `json:"expires_in"`
+		TokenType   string `json:"token_type"`
+	}{}
+
+	err = json.Unmarshal(body, &data)
+	if err != nil {
+		return token, err
+	}
+
+	return data.AccessToken, nil
+}
+
 // Config contains the variables you may want to change
 type Config struct {
 	// CodeURL is the endpoint to redirect to obtain a code

--- a/install.go
+++ b/install.go
@@ -69,8 +69,6 @@ func register(config Config, configFile, token string) {
 		check(err, "deviceAuth")
 	}
 
-	fmt.Println(token)
-
 	// Generate a Private Key and CSR
 	csr := generateKeyAndCsr(config)
 

--- a/install.go
+++ b/install.go
@@ -65,7 +65,7 @@ func register(config Config, configFile, token string) {
 	// Request token
 	var err error
 	if token == "" {
-		token, err = deviceAuth(config.AuthURL)
+		token, err = deviceAuth(config.AuthURL, config.AuthClientID)
 		check(err, "deviceAuth")
 	}
 
@@ -146,8 +146,8 @@ func registerDeviceViaMQTT(config Config) {
 }
 
 // Implements Auth0 device authentication flow: https://auth0.com/docs/flows/guides/device-auth/call-api-device-auth
-func deviceAuth(authURL string) (token string, err error) {
-	code, err := auth.StartDeviceAuth(authURL)
+func deviceAuth(authURL, clientID string) (token string, err error) {
+	code, err := auth.StartDeviceAuth(authURL, clientID)
 	if err != nil {
 		return "", err
 	}
@@ -166,7 +166,7 @@ Loop:
 			break Loop
 		case <-ticker.C:
 			var err error
-			token, err = auth.CheckDeviceAuth(authURL, code.DeviceCode)
+			token, err = auth.CheckDeviceAuth(authURL, clientID, code.DeviceCode)
 			if err == nil {
 				cancel()
 			}

--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	docker "github.com/docker/docker/client"
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/fsnotify/fsnotify"
 	"github.com/hpcloud/tail"
 	"github.com/namsral/flag"
@@ -108,8 +108,8 @@ func main() {
 	flag.StringVar(&config.HTTPProxy, "http_proxy", "", "URL of HTTP proxy to use")
 	flag.StringVar(&config.HTTPSProxy, "https_proxy", "", "URL of HTTPS proxy to use")
 	flag.StringVar(&config.ALLProxy, "all_proxy", "", "URL of SOCKS proxy to use")
-	flag.StringVar(&config.AuthURL, "authurl", "https://hydra.arduino.cc", "Url of authentication server")
-	flag.StringVar(&config.APIURL, "apiurl", "https://api2.arduino.cc", "Url of api server")
+	flag.StringVar(&config.AuthURL, "authurl", "https://login.oniudra.cc", "Url of authentication server")
+	flag.StringVar(&config.APIURL, "apiurl", "https://api-dev.arduino.cc", "Url of api server")
 	flag.BoolVar(&config.CheckRoFs, "check_ro_fs", false, "Check for Read Only file system and remount if necessary")
 	flag.BoolVar(&debugMqtt, "debug-mqtt", false, "Output all received/sent messages")
 	flag.StringVar(&config.SignatureKey, "signature_key", "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----", "key for verifying sketch binary signature")
@@ -128,7 +128,7 @@ func main() {
 	check(err, "CreateService")
 
 	if *doLogin {
-		token, err := askCredentials(config.AuthURL)
+		token, err := deviceAuth(config.AuthURL)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -111,7 +111,7 @@ func main() {
 	flag.StringVar(&config.HTTPSProxy, "https_proxy", "", "URL of HTTPS proxy to use")
 	flag.StringVar(&config.ALLProxy, "all_proxy", "", "URL of SOCKS proxy to use")
 	flag.StringVar(&config.AuthURL, "authurl", "https://login.arduino.cc", "Url of authentication server")
-	flag.StringVar(&config.APIURL, "apiurl", "https://api-dev.arduino.cc", "Url of api server")
+	flag.StringVar(&config.APIURL, "apiurl", "https://api2.arduino.cc", "Url of api server")
 	flag.BoolVar(&config.CheckRoFs, "check_ro_fs", false, "Check for Read Only file system and remount if necessary")
 	flag.BoolVar(&debugMqtt, "debug-mqtt", false, "Output all received/sent messages")
 	flag.StringVar(&config.SignatureKey, "signature_key", "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----", "key for verifying sketch binary signature")

--- a/main.go
+++ b/main.go
@@ -110,15 +110,22 @@ func main() {
 	flag.StringVar(&config.HTTPProxy, "http_proxy", "", "URL of HTTP proxy to use")
 	flag.StringVar(&config.HTTPSProxy, "https_proxy", "", "URL of HTTPS proxy to use")
 	flag.StringVar(&config.ALLProxy, "all_proxy", "", "URL of SOCKS proxy to use")
-	flag.StringVar(&config.AuthURL, "authurl", "https://login.oniudra.cc", "Url of authentication server")
+	flag.StringVar(&config.AuthURL, "authurl", "https://login.arduino.cc", "Url of authentication server")
 	flag.StringVar(&config.APIURL, "apiurl", "https://api-dev.arduino.cc", "Url of api server")
-	flag.StringVar(&config.AuthClientID, "authclientid", "", "Client ID for authentication server")
 	flag.BoolVar(&config.CheckRoFs, "check_ro_fs", false, "Check for Read Only file system and remount if necessary")
 	flag.BoolVar(&debugMqtt, "debug-mqtt", false, "Output all received/sent messages")
 	flag.StringVar(&config.SignatureKey, "signature_key", "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----", "key for verifying sketch binary signature")
 	flag.StringVar(&config.EnvVarsToLoad, "env_vars_to_load", "", "List of comma-separated Environment variables to load from system before launching sketches binaries")
 
 	flag.Parse()
+
+	if config.AuthURL == "https://login.oniudra.cc" {
+		config.AuthClientID = "ks1R298bA8IQnG4p6dPlbdEIXF6Kt1Lu"
+	}
+
+	if config.AuthURL == "https://login.arduino.cc" {
+		config.AuthClientID = "QGdLCWFA4uQdbRE2NOFhUI8bnXWMZhCK"
+	}
 
 	if *configFile == "" {
 		*configFile = defaultConfigFile

--- a/main.go
+++ b/main.go
@@ -59,6 +59,7 @@ type Config struct {
 	HTTPSProxy    string
 	ALLProxy      string
 	AuthURL       string
+	AuthClientID  string
 	APIURL        string
 	updateURL     string
 	appName       string
@@ -76,6 +77,7 @@ func (c Config) String() string {
 	out += "https_proxy=" + c.HTTPSProxy + "\r\n"
 	out += "all_proxy=" + c.ALLProxy + "\r\n"
 	out += "authurl=" + c.AuthURL + "\r\n"
+	out += "auth_client_id=" + c.AuthClientID + "\r\n"
 	out += "apiurl=" + c.APIURL + "\r\n"
 	out += "cert_path=" + c.CertPath + "\r\n"
 	out += "sketches_path=" + c.SketchesPath + "\r\n"
@@ -110,6 +112,7 @@ func main() {
 	flag.StringVar(&config.ALLProxy, "all_proxy", "", "URL of SOCKS proxy to use")
 	flag.StringVar(&config.AuthURL, "authurl", "https://login.oniudra.cc", "Url of authentication server")
 	flag.StringVar(&config.APIURL, "apiurl", "https://api-dev.arduino.cc", "Url of api server")
+	flag.StringVar(&config.AuthClientID, "authclientid", "", "Client ID for authentication server")
 	flag.BoolVar(&config.CheckRoFs, "check_ro_fs", false, "Check for Read Only file system and remount if necessary")
 	flag.BoolVar(&debugMqtt, "debug-mqtt", false, "Output all received/sent messages")
 	flag.StringVar(&config.SignatureKey, "signature_key", "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvc0yZr1yUSen7qmE3cxF\nIE12rCksDnqR+Hp7o0nGi9123eCSFcJ7CkIRC8F+8JMhgI3zNqn4cUEn47I3RKD1\nZChPUCMiJCvbLbloxfdJrUi7gcSgUXrlKQStOKF5Iz7xv1M4XOP3JtjXLGo3EnJ1\npFgdWTOyoSrA8/w1rck4c/ISXZSinVAggPxmLwVEAAln6Itj6giIZHKvA2fL2o8z\nCeK057Lu8X6u2CG8tRWSQzVoKIQw/PKK6CNXCAy8vo4EkXudRutnEYHEJlPkVgPn\n2qP06GI+I+9zKE37iqj0k1/wFaCVXHXIvn06YrmjQw6I0dDj/60Wvi500FuRVpn9\ntwIDAQAB\n-----END PUBLIC KEY-----", "key for verifying sketch binary signature")
@@ -128,7 +131,7 @@ func main() {
 	check(err, "CreateService")
 
 	if *doLogin {
-		token, err := deviceAuth(config.AuthURL)
+		token, err := deviceAuth(config.AuthURL, config.AuthClientID)
 		if err != nil {
 			fmt.Fprintln(os.Stderr, err)
 			os.Exit(1)


### PR DESCRIPTION
Running the arduino-connector without explicitly passing a token would cause the arduino-connector to generate a code and ask the user to login in a website and enter the code.

This ensures that the arduino-connector can obtain a short-lived token securely, leveraging the eventual 2-factor authentication