### PR TITLE
Functional tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,16 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  CI:
+    name: CI
+    runs-on: ubuntu-latest
+    container: guerra1994/go-mqtt-docker-env
+
+    steps:
+      - name: check out code
+        uses: actions/checkout@v2
+
+      - name: build
+        run: go build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,10 +1,10 @@
-name: CI
+name: tests
 
 on: [push, pull_request]
 
 jobs:
   CI:
-    name: CI
+    name: tests
     runs-on: ubuntu-latest
     container: guerra1994/go-mqtt-docker-env
 
@@ -12,5 +12,8 @@ jobs:
       - name: check out code
         uses: actions/checkout@v2
 
-      - name: build
-        run: go build
+      - name: download mod
+        run: go mod download
+
+      - name: run functional tests
+        run: ./scripts/functional-tests.sh

--- a/.gitignore
+++ b/.gitignore
@@ -58,4 +58,7 @@ arduino-connector-arm
 .idea
 setup_host_test_env.sh
 
+### Remote vscode container
+.devcontainer/*
+
 # End

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ go get github.com/sanbornm/go-selfupdate
 
 See [API](./API.md)
 
+## Functional tests
+
+This type of tests are executed all locally and you need to configure a dedicated docker container:
+- `docker pull guerra1994/go-mqtt-docker-env`
+- follow step to run correctly container (https://hub.docker.com/r/guerra1994/go-mqtt-docker-env)
+- run mosquitto broker in background mode using `mosquitto &`
+- then run your test, for example `go test -v --run="TestDockerPsApi"`
+
+
 ## Integration tests disclaimer
 
 You will see in the following paragraphs that the testing environment and procedures are strictly coupled with the

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ See [API](./API.md)
 
 This type of tests are executed all locally and you need to configure a dedicated docker container:
 - `docker pull guerra1994/go-mqtt-docker-env`
-- follow step to run correctly container (https://hub.docker.com/r/guerra1994/go-mqtt-docker-env)
+- follow the steps [here](https://hub.docker.com/r/guerra1994/go-mqtt-docker-env) to run it
 - run mosquitto broker in background mode using `mosquitto &`
 - then run your test, for example `go test -v --run="TestDockerPsApi"`
 

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	github.com/shirou/gopsutil v2.17.13-0.20180801053943-8048a2e9c577+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect
 	github.com/sirupsen/logrus v1.1.0 // indirect
-	github.com/stretchr/testify v1.2.2
+	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19 h1:HSgjWPBWohO3kHDPwCPUGSLqJjXCjA7ad5057beR2ZU=
 github.com/containerd/continuity v0.0.0-20181003075958-be9bd761db19/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/cli v0.0.0-20180905184309-44371c7c34d5 h1:FGNHsOn20/i4y8Ck+qQ8rXSN9j7IuBhqcMC+HGpbTHE=
@@ -121,8 +122,11 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+D
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/sirupsen/logrus v1.1.0 h1:65VZabgUiV9ktjGM5nTq0+YurgTyX+YI2lSSfDjI+qU=
 github.com/sirupsen/logrus v1.1.0/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793 h1:u+LnwYTOOW7Ukr/fppxEb1Nwz0AtPflrblfvUudpo+I=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,7 @@ github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+D
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
 github.com/sirupsen/logrus v1.1.0 h1:65VZabgUiV9ktjGM5nTq0+YurgTyX+YI2lSSfDjI+qU=
 github.com/sirupsen/logrus v1.1.0/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/handlers.go
+++ b/handlers.go
@@ -131,7 +131,7 @@ func (status *Status) UploadEvent(client mqtt.Client, msg mqtt.Message) {
 		if _, err = os.Stat(sketchPath); !os.IsNotExist(err) {
 			err = os.Remove(sketchPath)
 			if err != nil {
-				status.Error("/upload", errors.Wrapf(err, "remove %d", sketch.Name))
+				status.Error("/upload", errors.Wrapf(err, "remove %s", sketch.Name))
 				return
 			}
 		}

--- a/handlers_containers.go
+++ b/handlers_containers.go
@@ -37,7 +37,7 @@ import (
 	"github.com/docker/docker/api/types/filters"
 	"github.com/docker/docker/api/types/network"
 	docker "github.com/docker/docker/client"
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/pkg/errors"
 	"github.com/shirou/gopsutil/host"
 	"golang.org/x/net/context"

--- a/handlers_containers.go
+++ b/handlers_containers.go
@@ -1,7 +1,7 @@
 //
 //  This file is part of arduino-connector
 //
-//  Copyright (C) 2017-2018  Arduino AG (http://www.arduino.cc/)
+//  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/handlers_containers.go
+++ b/handlers_containers.go
@@ -105,7 +105,9 @@ func (s *Status) ContainerPsEventImpl(client mqtt.Client, msg mqtt.Message) (dat
 func (s *Status) ContainersPsEventAWS(client mqtt.Client, msg mqtt.Message) {
 	data := s.ContainerPsEventImpl(client, msg)
 	fmt.Println("aws data: ", data)
-	s.SendInfo("$aws/things/"+s.id+"/containers/ps", string(data)+"\n")
+	if !s.SendInfo("$aws/things/"+s.id+"/containers/ps", string(data)+"\n") {
+		fmt.Println("error sending info")
+	}
 }
 
 // ContainersPsEvent send info about "docker ps -a" command

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -74,6 +74,9 @@ func TestDockerPsApi(t *testing.T) {
 	}
 
 	assert.Equal(t, len(result), len(splitted))
+	for i, v := range splitted {
+		assert.True(t, strings.HasPrefix(result[i].ID, v[:12]))
+	}
 
 	status.mqttClient.Disconnect(100)
 }

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -27,12 +27,77 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	docker "github.com/docker/docker/client"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 
 	"github.com/stretchr/testify/assert"
 )
 
-// tests
+func assertEqual(t *testing.T, a interface{}, b interface{}) {
+	if a != b {
+		t.Fatalf("%s != %s", a, b)
+	}
+}
+
+func TestDockerPsApi(t *testing.T) {
+	topic := "/containers/ps"
+	broker := "tcp://localhost:1883"
+
+	uiOptions := mqtt.NewClientOptions().AddBroker(broker).SetClientID("UI")
+	ans := make(chan string)
+	msgRcvd := func(client mqtt.Client, msg mqtt.Message) {
+		s := string(msg.Payload())
+		if s != "{}" {
+			ans <- s
+		}
+	}
+	uiOptions.SetDefaultPublishHandler(msgRcvd)
+
+	uiOptions.OnConnect = func(c mqtt.Client) {
+		if token := c.Subscribe(topic, 0, nil); token.Wait() && token.Error() != nil {
+			t.Error(token.Error())
+		}
+	}
+
+	ui := mqtt.NewClient(uiOptions)
+
+	if token := ui.Connect(); token.Wait() && token.Error() != nil {
+		t.Error(token.Error())
+	}
+
+	var p program
+
+	status := NewStatus(p.Config, nil, nil)
+	status.dockerClient, _ = docker.NewClientWithOpts(docker.WithVersion("1.38"))
+
+	acOptions := mqtt.NewClientOptions().AddBroker(broker).SetClientID("arduino-connector")
+	status.mqttClient = mqtt.NewClient(acOptions)
+
+	if token := status.mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		t.Fatal(token.Error())
+	}
+
+	subscribeTopic(status.mqttClient, p.Config.ID, topic, status, status.ContainersPsEvent, false)
+
+	if token := ui.Publish(topic, 0, false, "{}"); token.Wait() && token.Error() != nil {
+		t.Fatal(token.Error())
+	}
+
+	goldMqttResponse := "INFO: []\n\n"
+	assertEqual(t, <-ans, goldMqttResponse)
+
+	if token := ui.Unsubscribe(topic); token.Wait() && token.Error() != nil {
+		t.Error(token.Error())
+	}
+
+	if token := status.mqttClient.Unsubscribe(topic); token.Wait() && token.Error() != nil {
+		t.Error(token.Error())
+	}
+
+	ui.Disconnect(250)
+	status.mqttClient.Disconnect(250)
+}
+
 func TestConnectorProcessIsRunning(t *testing.T) {
 	outputMessage, err := ExecAsVagrantSshCmd("systemctl status ArduinoConnector | grep running")
 	if err != nil {

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +51,17 @@ func TestDockerPsApi(t *testing.T) {
 	resp := ui.MqttSendAndReceiveTimeout(t, "/containers/ps", "{}", 1*time.Millisecond)
 	goldMqttResponse := "INFO: []\n\n"
 	assert.Equal(t, goldMqttResponse, resp)
+
+	cmd := exec.Command("bash", "-c", "docker ps", "-c")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// NOTE: check only second string because first is docker header
+	strOut := string(out)
+	splitted := strings.Split(strOut, "\n")
+	assert.Equal(t, "", splitted[1])
 
 	status.mqttClient.Disconnect(100)
 }

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -38,7 +38,7 @@ func TestDockerPsApi(t *testing.T) {
 	ui := NewMqttTestClientLocal()
 	defer ui.Close()
 
-	status := NewStatus(program{}.Config, nil, nil)
+	status := NewStatus(program{}.Config, nil, nil, "")
 	status.dockerClient, _ = docker.NewClientWithOpts(docker.WithVersion("1.38"))
 	acOptions := mqtt.NewClientOptions().AddBroker("tcp://localhost:1883").SetClientID("arduino-connector")
 	status.mqttClient = mqtt.NewClient(acOptions)

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -36,6 +36,7 @@ import (
 
 func TestDockerPsApi(t *testing.T) {
 	ui := NewMqttTestClientLocal()
+	defer ui.Close()
 
 	status := NewStatus(program{}.Config, nil, nil)
 	status.dockerClient, _ = docker.NewClientWithOpts(docker.WithVersion("1.38"))

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -1,7 +1,7 @@
 //
 //  This file is part of arduino-connector
 //
-//  Copyright (C) 2017-2018  Arduino AG (http://www.arduino.cc/)
+//  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -49,7 +49,7 @@ func TestDockerPsApi(t *testing.T) {
 
 	subscribeTopic(status.mqttClient, "0", "/containers/ps/post", status, status.ContainersPsEvent, false)
 
-	resp := ui.MqttSendAndReceiveTimeout(t, "/containers/ps", "{}", 1*time.Millisecond)
+	resp := ui.MqttSendAndReceiveTimeout(t, "/containers/ps", "{}", 50*time.Millisecond)
 	goldMqttResponse := "INFO: []\n\n"
 	assert.Equal(t, goldMqttResponse, resp)
 

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/docker/docker/api/types"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -58,12 +58,9 @@ func TestDockerPsApi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	strOut := string(out)
-	splitted := strings.Split(strOut, "\n")
-	// Remove first because docker header
-	splitted = splitted[1:]
-	// Remove last becaus is empty line
-	splitted = splitted[:len(splitted)-1]
+	lines := strings.Split(string(out), "\n")
+	// Remove the first line (command output header) and the last line (empty line)
+	lines = lines[1 : len(lines)-1]
 
 	// Take json without INFO tag
 	resp = strings.TrimPrefix(resp, "INFO: ")
@@ -73,9 +70,10 @@ func TestDockerPsApi(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, len(result), len(splitted))
-	for i, v := range splitted {
-		assert.True(t, strings.HasPrefix(result[i].ID, v[:12]))
+	assert.Equal(t, len(result), len(lines))
+	for i, line := range lines {
+		containerId := strings.Fields(line)[0]
+		assert.True(t, strings.HasPrefix(result[i].ID, containerId))
 	}
 
 	status.mqttClient.Disconnect(100)

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -53,13 +53,14 @@ func TestDockerPsApi(t *testing.T) {
 	goldMqttResponse := "INFO: []\n\n"
 	assert.Equal(t, goldMqttResponse, resp)
 
-	cmd := exec.Command("bash", "-c", "docker ps", "-c")
+	// ask Docker about containers effectively running
+	cmd := exec.Command("bash", "-c", "docker ps -a")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// NOTE: check only second string because first is docker header
+	// NOTE: we must discard docker output header line
 	strOut := string(out)
 	splitted := strings.Split(strOut, "\n")
 	assert.Equal(t, "", splitted[1])

--- a/handlers_containers_test.go
+++ b/handlers_containers_test.go
@@ -66,9 +66,10 @@ func TestDockerPsApi(t *testing.T) {
 	splitted = splitted[:len(splitted)-1]
 
 	// Take json without INFO tag
-	respJSON := strings.Replace(resp, "INFO: ", "", -1)
-	var result []interface{}
-	if err := json.Unmarshal([]byte(respJSON), &result); err != nil {
+	resp = strings.TrimPrefix(resp, "INFO: ")
+	resp = strings.TrimSuffix(resp, "\n\n")
+	var result []types.Container
+	if err := json.Unmarshal([]byte(resp), &result); err != nil {
 		t.Fatal(err)
 	}
 

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -118,6 +118,8 @@ func (tmc *MqttTestClient) Close() {
 }
 
 func (tmc *MqttTestClient) MqttSendAndReceiveTimeout(t *testing.T, topic, request string, timeout time.Duration) string {
+	t.Helper()
+
 	respChan := make(chan string)
 	if token := tmc.client.Subscribe(topic, 0, func(client mqtt.Client, msg mqtt.Message) {
 		respChan <- string(msg.Payload())

--- a/handlers_test.go
+++ b/handlers_test.go
@@ -51,6 +51,19 @@ type MqttTestClient struct {
 	thingToTestId string
 }
 
+func NewMqttTestClientLocal() *MqttTestClient {
+	uiOptions := mqtt.NewClientOptions().AddBroker("tcp://localhost:1883").SetClientID("UI")
+	ui := mqtt.NewClient(uiOptions)
+	if token := ui.Connect(); token.Wait() && token.Error() != nil {
+		panic(token.Error())
+	}
+
+	return &MqttTestClient{
+		ui,
+		"",
+	}
+}
+
 func NewMqttTestClient() *MqttTestClient {
 	cert := "test/cert.pem"
 	key := "test/privateKey.pem"

--- a/main.go
+++ b/main.go
@@ -1,7 +1,7 @@
 //
 //  This file is part of arduino-connector
 //
-//  Copyright (C) 2017-2018  Arduino AG (http://www.arduino.cc/)
+//  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/main.go
+++ b/main.go
@@ -215,7 +215,7 @@ func (p program) run() {
 	}
 
 	// Create global status
-	status := NewStatus(p.Config, nil, nil)
+	status := NewStatus(p.Config, nil, nil, "$aws/things/"+p.Config.ID)
 	status.Update(p.Config)
 
 	// Setup MQTT connection
@@ -324,7 +324,7 @@ func subscribeTopics(mqttClient mqtt.Client, id string, status *Status) {
 	subscribeTopicAWS(mqttClient, id, "/apt/repos/remove/post", status, status.AptRepositoryRemoveEvent, true)
 	subscribeTopicAWS(mqttClient, id, "/apt/repos/edit/post", status, status.AptRepositoryEditEvent, true)
 
-	subscribeTopicAWS(mqttClient, id, "/containers/ps/post", status, status.ContainersPsEventAWS, false)
+	subscribeTopicAWS(mqttClient, id, "/containers/ps/post", status, status.ContainersPsEvent, false)
 	subscribeTopicAWS(mqttClient, id, "/containers/images/post", status, status.ContainersListImagesEvent, false)
 	subscribeTopicAWS(mqttClient, id, "/containers/action/post", status, status.ContainersActionEvent, true)
 	subscribeTopicAWS(mqttClient, id, "/containers/rename/post", status, status.ContainersRenameEvent, true)

--- a/main.go
+++ b/main.go
@@ -304,37 +304,35 @@ func subscribeTopics(mqttClient mqtt.Client, id string, status *Status) {
 	if status == nil {
 		return
 	}
-	subscribeTopic(mqttClient, id, "/status/post", status, status.StatusEvent, false)
-	subscribeTopic(mqttClient, id, "/upload/post", status, status.UploadEvent, true)
-	subscribeTopic(mqttClient, id, "/sketch/post", status, status.SketchEvent, true)
-	subscribeTopic(mqttClient, id, "/update/post", status, status.UpdateEvent, true)
-	subscribeTopic(mqttClient, id, "/stats/post", status, status.StatsEvent, false)
-	subscribeTopic(mqttClient, id, "/wifi/post", status, status.WiFiEvent, true)
-	subscribeTopic(mqttClient, id, "/ethernet/post", status, status.EthEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/status/post", status, status.StatusEvent, false)
+	subscribeTopicAWS(mqttClient, id, "/upload/post", status, status.UploadEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/sketch/post", status, status.SketchEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/update/post", status, status.UpdateEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/stats/post", status, status.StatsEvent, false)
+	subscribeTopicAWS(mqttClient, id, "/wifi/post", status, status.WiFiEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/ethernet/post", status, status.EthEvent, true)
 
-	subscribeTopic(mqttClient, id, "/apt/get/post", status, status.AptGetEvent, false)
-	subscribeTopic(mqttClient, id, "/apt/list/post", status, status.AptListEvent, false)
-	subscribeTopic(mqttClient, id, "/apt/install/post", status, status.AptInstallEvent, true)
-	subscribeTopic(mqttClient, id, "/apt/update/post", status, status.AptUpdateEvent, true)
-	subscribeTopic(mqttClient, id, "/apt/upgrade/post", status, status.AptUpgradeEvent, true)
-	subscribeTopic(mqttClient, id, "/apt/remove/post", status, status.AptRemoveEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/get/post", status, status.AptGetEvent, false)
+	subscribeTopicAWS(mqttClient, id, "/apt/list/post", status, status.AptListEvent, false)
+	subscribeTopicAWS(mqttClient, id, "/apt/install/post", status, status.AptInstallEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/update/post", status, status.AptUpdateEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/upgrade/post", status, status.AptUpgradeEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/remove/post", status, status.AptRemoveEvent, true)
 
-	subscribeTopic(mqttClient, id, "/apt/repos/list/post", status, status.AptRepositoryListEvent, false)
-	subscribeTopic(mqttClient, id, "/apt/repos/add/post", status, status.AptRepositoryAddEvent, true)
-	subscribeTopic(mqttClient, id, "/apt/repos/remove/post", status, status.AptRepositoryRemoveEvent, true)
-	subscribeTopic(mqttClient, id, "/apt/repos/edit/post", status, status.AptRepositoryEditEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/repos/list/post", status, status.AptRepositoryListEvent, false)
+	subscribeTopicAWS(mqttClient, id, "/apt/repos/add/post", status, status.AptRepositoryAddEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/repos/remove/post", status, status.AptRepositoryRemoveEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/apt/repos/edit/post", status, status.AptRepositoryEditEvent, true)
 
-	subscribeTopic(mqttClient, id, "/containers/ps/post", status, status.ContainersPsEvent, false)
-	subscribeTopic(mqttClient, id, "/containers/images/post", status, status.ContainersListImagesEvent, false)
-	subscribeTopic(mqttClient, id, "/containers/action/post", status, status.ContainersActionEvent, true)
-	subscribeTopic(mqttClient, id, "/containers/rename/post", status, status.ContainersRenameEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/containers/ps/post", status, status.ContainersPsEventAWS, false)
+	subscribeTopicAWS(mqttClient, id, "/containers/images/post", status, status.ContainersListImagesEvent, false)
+	subscribeTopicAWS(mqttClient, id, "/containers/action/post", status, status.ContainersActionEvent, true)
+	subscribeTopicAWS(mqttClient, id, "/containers/rename/post", status, status.ContainersRenameEvent, true)
 }
 
-func subscribeTopic(mqttClient mqtt.Client, id, topic string, status *Status, statusHandler mqtt.MessageHandler, isWriteFsRequiredForTopic bool) {
-	handler := statusHandler
-
+func subscribeTopicImpl(mqttClient mqtt.Client, id, topic string, status *Status, statusHandler mqtt.MessageHandler, isWriteFsRequiredForTopic bool) mqtt.MessageHandler {
 	if status.config.CheckRoFs && isWriteFsRequiredForTopic {
-		handler = func(client mqtt.Client, msg mqtt.Message) {
+		return func(client mqtt.Client, msg mqtt.Message) {
 			mountRootFilesystemRw()
 			statusHandler(client, msg)
 			mountRootFilesystemRo()
@@ -342,13 +340,24 @@ func subscribeTopic(mqttClient mqtt.Client, id, topic string, status *Status, st
 	}
 
 	if debugMqtt {
-		debugHandler := func(client mqtt.Client, msg mqtt.Message) {
+		return func(client mqtt.Client, msg mqtt.Message) {
 			fmt.Println("MQTT IN:", string(msg.Topic()), string(msg.Payload()))
-			handler(client, msg)
+			statusHandler(client, msg)
 		}
-		mqttClient.Subscribe("$aws/things/"+id+topic, 1, debugHandler)
-	} else {
-		mqttClient.Subscribe("$aws/things/"+id+topic, 1, handler)
+	}
+
+	return statusHandler
+}
+
+func subscribeTopicAWS(mqttClient mqtt.Client, id, topic string, status *Status, statusHandler mqtt.MessageHandler, isWriteFsRequiredForTopic bool) {
+	handler := subscribeTopicImpl(mqttClient, id, topic, status, statusHandler, isWriteFsRequiredForTopic)
+	mqttClient.Subscribe("$aws/things/"+id+topic, 1, handler)
+}
+
+func subscribeTopic(mqttClient mqtt.Client, id, topic string, status *Status, statusHandler mqtt.MessageHandler, isWriteFsRequiredForTopic bool) {
+	handler := subscribeTopicImpl(mqttClient, id, topic, status, statusHandler, isWriteFsRequiredForTopic)
+	if token := mqttClient.Subscribe(topic, 0, handler); token.Wait() && token.Error() != nil {
+		fmt.Println(token.Error())
 	}
 }
 

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+mosquitto &
+sleep 5
+go test -v --run="TestDockerPsApi"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -4,5 +4,5 @@ set -euo pipefail
 
 trap 'kill "$(pidof mosquitto)"' EXIT
 
-mosquitto &
+mosquitto > /dev/null &
 go test -v --run="TestDockerPsApi"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -5,5 +5,4 @@ set -euo pipefail
 trap 'kill "$(pidof mosquitto)"' EXIT
 
 mosquitto &
-sleep 5
 go test -v --run="TestDockerPsApi"

--- a/scripts/functional-tests.sh
+++ b/scripts/functional-tests.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trap 'kill "$(pidof mosquitto)"' EXIT
 
 mosquitto &
 sleep 5

--- a/status.go
+++ b/status.go
@@ -122,6 +122,25 @@ func (s *Status) Info(topic, msg string) bool {
 	return res
 }
 
+// SendInfo send information to a specific topic
+func (s *Status) SendInfo(topic, msg string) bool {
+	if s.mqttClient == nil {
+		return false
+	}
+
+	s.messagesSent++
+
+	if token := s.mqttClient.Publish(topic, 0, false, "INFO: "+msg+"\n"); token.Wait() && token.Error() != nil {
+		fmt.Println(token.Error())
+	}
+
+	if debugMqtt {
+		fmt.Println("MQTT OUT: "+topic, "INFO: "+msg+"\n")
+	}
+
+	return true
+}
+
 // Raw sends a message on the specified topic without further processing
 func (s *Status) Raw(topic, msg string) {
 	if s.mqttClient == nil {

--- a/status.go
+++ b/status.go
@@ -32,13 +32,14 @@ import (
 
 // Status contains info about the sketches running on the device
 type Status struct {
-	config         Config
-	id             string
-	mqttClient     mqtt.Client
-	dockerClient   docker.APIClient
-	Sketches       map[string]*SketchStatus `json:"sketches"`
-	messagesSent   int
-	firstMessageAt time.Time
+	config          Config
+	id              string
+	mqttClient      mqtt.Client
+	dockerClient    docker.APIClient
+	Sketches        map[string]*SketchStatus `json:"sketches"`
+	messagesSent    int
+	firstMessageAt  time.Time
+	topicPertinence string
 }
 
 // SketchBinding represents a pair (SketchName,SketchId)
@@ -64,13 +65,14 @@ type Endpoint struct {
 }
 
 // NewStatus creates a new status that publishes on a topic
-func NewStatus(config Config, mqttClient mqtt.Client, dockerClient docker.APIClient) *Status {
+func NewStatus(config Config, mqttClient mqtt.Client, dockerClient docker.APIClient, topicPertinence string) *Status {
 	return &Status{
-		config:       config,
-		id:           config.ID,
-		mqttClient:   mqttClient,
-		dockerClient: dockerClient,
-		Sketches:     map[string]*SketchStatus{},
+		config:          config,
+		id:              config.ID,
+		mqttClient:      mqttClient,
+		dockerClient:    dockerClient,
+		Sketches:        map[string]*SketchStatus{},
+		topicPertinence: topicPertinence,
 	}
 }
 

--- a/status.go
+++ b/status.go
@@ -1,7 +1,7 @@
 //
 //  This file is part of arduino-connector
 //
-//  Copyright (C) 2017-2018  Arduino AG (http://www.arduino.cc/)
+//  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
 //  you may not use this file except in compliance with the License.

--- a/status.go
+++ b/status.go
@@ -26,7 +26,7 @@ import (
 	"time"
 
 	docker "github.com/docker/docker/client"
-	"github.com/eclipse/paho.mqtt.golang"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
The purpose of this PR is to add a structure for running locally functional tests about API.
For this, we are using a docker image while developing in order to have a reproducible environment also for CI on GitHub, the link for image https://hub.docker.com/r/guerra1994/go-mqtt-docker-env.
The documentation is updated also about running tests in local machines.
I just added a test for `docker ps -a` API and it checks the output of the command executed on bash and the message from broker MQTT. It allows us to avoid to follow a sequential order running tests but is consistent with what container are in the machine because it checks that 2 output figure out the same container id.
In order to automate steps explained in README.md there is a script that starts `mosquitto`, exec tests and kills it, to restore a correct state of the docker container.