### PR TITLE
Move binary in /usr/bin

### DIFF
--- a/arduino-connector.sh
+++ b/arduino-connector.sh
@@ -3,7 +3,7 @@
 #
 #  This file is part of arduino-connector
 #
-#  Copyright (C) 2017-2018  Arduino AG (http://www.arduino.cc/)
+#  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -71,17 +71,17 @@ fi
 echo download connector
 echo ---------
 download https://downloads.arduino.cc/tools/feed/arduino-connector/arduino-connector
-chmod +x arduino-connector
+sudo mv arduino-connector /usr/bin/arduino-connector
+sudo chmod +x /usr/bin/arduino-connector
 
 echo install connector
 echo ---------
 if [ "$password" == "" ]
 then
-	sudo -E ./arduino-connector -register -install
+	sudo -E arduino-connector -register -install
 else
-	echo $password | sudo -kS -E ./arduino-connector -register -install > arduino-connector.log 2>&1
+	echo $password | sudo -kS -E arduino-connector -register -install > arduino-connector.log 2>&1
 fi
-
 
 echo start connector service
 echo ---------

--- a/install.go
+++ b/install.go
@@ -42,7 +42,6 @@ import (
 	"github.com/arduino/arduino-connector/auth"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/facchinm/service"
-	"github.com/kardianos/osext"
 	"github.com/pkg/errors"
 )
 
@@ -350,14 +349,12 @@ func (p *program) Stop(s service.Service) error {
 
 // createService returns the servcie to be installed
 func createService(config Config, configFile, listenFile string) (service.Service, error) {
-	workingDirectory, _ := osext.ExecutableFolder()
-
 	svcConfig := &service.Config{
 		Name:             "ArduinoConnector",
 		DisplayName:      "Arduino Connector Service",
 		Description:      "Cloud connector and launcher for IoT devices.",
 		Arguments:        []string{"-config", configFile},
-		WorkingDirectory: workingDirectory,
+		WorkingDirectory: "/usr/bin",
 		Dependencies:     []string{"network-online.target"},
 	}
 


### PR DESCRIPTION
This fix #80, in this way the path for service is /usr/bin and during
script of installation will be moved in that path.

Signed-off-by: Federico Guerinoni <guerra@develer.com>