### PR TITLE
Move binary in /usr/bin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   Tests:
     runs-on: ubuntu-latest
-    container: ghcr.io/guerinoni/go-docker-mqtt-ubuntu-env:latest
+    container: guerra1994/go-docker-mqtt-ubuntu-env
 
     steps:
       - name: check out code

--- a/arduino-connector-arm.sh
+++ b/arduino-connector-arm.sh
@@ -1,5 +1,23 @@
 #!/bin/bash -e
 
+#
+#  This file is part of arduino-connector
+#
+#  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
 has() {
 	type "$1" > /dev/null 2>&1
 	return $?
@@ -53,18 +71,17 @@ fi
 echo download connector
 echo ---------
 download https://downloads.arduino.cc/tools/feed/arduino-connector/arduino-connector-arm
-mv arduino-connector-arm arduino-connector
-chmod +x arduino-connector
+sudo mv arduino-connector-arm /usr/bin/arduino-connector
+sudo chmod +x /usr/bin/arduino-connector
 
 echo install connector
 echo ---------
 if [ "$password" == "" ]
 then
-	sudo -E ./arduino-connector -register -install
+	sudo -E arduino-connector -register -install
 else
-	echo $password | sudo -kS -E ./arduino-connector -register -install > arduino-connector.log 2>&1
+	echo $password | sudo -kS -E arduino-connector -register -install > arduino-connector.log 2>&1
 fi
-
 
 echo start connector service
 echo ---------

--- a/arduino-connector-arm.sh
+++ b/arduino-connector-arm.sh
@@ -50,7 +50,7 @@ echo ---------
 
 echo remove old files
 echo ---------
-rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
+sudo rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
 
 echo uninstall previous installations of connector
 echo ---------

--- a/arduino-connector-arm.sh
+++ b/arduino-connector-arm.sh
@@ -50,7 +50,7 @@ echo ---------
 
 echo remove old files
 echo ---------
-rm -f arduino-connector* certificate*
+rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
 
 echo uninstall previous installations of connector
 echo ---------

--- a/arduino-connector.sh
+++ b/arduino-connector.sh
@@ -50,7 +50,7 @@ echo ---------
 
 echo remove old files
 echo ---------
-rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
+sudo rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
 
 echo uninstall previous installations of connector
 echo ---------

--- a/arduino-connector.sh
+++ b/arduino-connector.sh
@@ -50,7 +50,7 @@ echo ---------
 
 echo remove old files
 echo ---------
-rm -f arduino-connector* certificate*
+rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
 
 echo uninstall previous installations of connector
 echo ---------

--- a/arduino-connector.sh
+++ b/arduino-connector.sh
@@ -3,7 +3,7 @@
 #
 #  This file is part of arduino-connector
 #
-#  Copyright (C) 2017-2018  Arduino AG (http://www.arduino.cc/)
+#  Copyright (C) 2017-2020  Arduino AG (http://www.arduino.cc/)
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -71,17 +71,17 @@ fi
 echo download connector
 echo ---------
 download https://downloads.arduino.cc/tools/feed/arduino-connector/arduino-connector
-chmod +x arduino-connector
+sudo mv arduino-connector /usr/bin/arduino-connector
+sudo chmod +x /usr/bin/arduino-connector
 
 echo install connector
 echo ---------
 if [ "$password" == "" ]
 then
-	sudo -E ./arduino-connector -register -install
+	sudo -E arduino-connector -register -install
 else
-	echo $password | sudo -kS -E ./arduino-connector -register -install > arduino-connector.log 2>&1
+	echo $password | sudo -kS -E arduino-connector -register -install > arduino-connector.log 2>&1
 fi
-
 
 echo start connector service
 echo ---------

--- a/install.go
+++ b/install.go
@@ -42,6 +42,7 @@ import (
 	"github.com/arduino/arduino-connector/auth"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/facchinm/service"
+	"github.com/kardianos/osext"
 	"github.com/pkg/errors"
 )
 
@@ -350,12 +351,14 @@ func (p *program) Stop(s service.Service) error {
 
 // createService returns the servcie to be installed
 func createService(config Config, configFile, listenFile string) (service.Service, error) {
+	workingDirectory, _ := osext.ExecutableFolder()
+
 	svcConfig := &service.Config{
 		Name:             "ArduinoConnector",
 		DisplayName:      "Arduino Connector Service",
 		Description:      "Cloud connector and launcher for IoT devices.",
 		Arguments:        []string{"-config", configFile},
-		WorkingDirectory: "/usr/bin",
+		WorkingDirectory: workingDirectory,
 		Dependencies:     []string{"network-online.target"},
 	}
 

--- a/install.go
+++ b/install.go
@@ -42,7 +42,6 @@ import (
 	"github.com/arduino/arduino-connector/auth"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 	"github.com/facchinm/service"
-	"github.com/kardianos/osext"
 	"github.com/pkg/errors"
 )
 
@@ -351,14 +350,12 @@ func (p *program) Stop(s service.Service) error {
 
 // createService returns the servcie to be installed
 func createService(config Config, configFile, listenFile string) (service.Service, error) {
-	workingDirectory, _ := osext.ExecutableFolder()
-
 	svcConfig := &service.Config{
 		Name:             "ArduinoConnector",
 		DisplayName:      "Arduino Connector Service",
 		Description:      "Cloud connector and launcher for IoT devices.",
 		Arguments:        []string{"-config", configFile},
-		WorkingDirectory: workingDirectory,
+		WorkingDirectory: "/usr/bin",
 		Dependencies:     []string{"network-online.target"},
 	}
 

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	defaultConfigFile = "./arduino-connector.cfg"
+	defaultConfigFile = "/usr/bin/arduino-connector.cfg"
 )
 
 var (
@@ -103,7 +103,7 @@ func main() {
 	flag.StringVar(&config.appName, "appName", "arduino-connector", "")
 
 	var configFile = flag.String(flag.DefaultConfigFlagname, "", "path to config file")
-	flag.StringVar(&config.CertPath, "cert_path", "./", "path to store certificates")
+	flag.StringVar(&config.CertPath, "cert_path", "/usr/bin/", "path to store certificates")
 	flag.StringVar(&config.SketchesPath, "sketches_path", "", "path to store sketches")
 	flag.StringVar(&config.ID, "id", "", "id of the thing in aws iot")
 	flag.StringVar(&config.URL, "url", "", "url of the thing in aws iot")

--- a/main.go
+++ b/main.go
@@ -111,6 +111,7 @@ func main() {
 	flag.StringVar(&config.HTTPSProxy, "https_proxy", "", "URL of HTTPS proxy to use")
 	flag.StringVar(&config.ALLProxy, "all_proxy", "", "URL of SOCKS proxy to use")
 	flag.StringVar(&config.AuthURL, "authurl", "https://login.arduino.cc", "Url of authentication server")
+	flag.StringVar(&config.AuthClientID, "auth_client_id", "", "Authentication client ID")
 	flag.StringVar(&config.APIURL, "apiurl", "https://api2.arduino.cc", "Url of api server")
 	flag.BoolVar(&config.CheckRoFs, "check_ro_fs", false, "Check for Read Only file system and remount if necessary")
 	flag.BoolVar(&debugMqtt, "debug-mqtt", false, "Output all received/sent messages")


### PR DESCRIPTION
This fix #234, in this way the path for service is /usr/bin and during
script of installation will be moved in that path.

Signed-off-by: Federico Guerinoni <guerra@develer.com>