### PR TITLE
Installation tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,5 +14,8 @@ jobs:
       - name: run mqtt tests
         run: ./scripts/mqtt-tests.sh
 
+      - name: run install tests
+        run: ./scripts/install-tests.sh
+
       - name: run auth tests
         run: go test -v ./auth

--- a/handlers_stats.go
+++ b/handlers_stats.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
-	"strings"
 
 	apt "github.com/arduino/go-apt-client"
 	"github.com/arduino/go-system-stats/disk"
@@ -70,25 +69,23 @@ func checkAndInstallNetworkManager() {
 	if err == nil {
 		return
 	}
-	if strings.Contains(err.Error(), "NetworkManager") {
-		// dpkg --configure -a for prevent block of installation
-		dpkgCmd := exec.Command("dpkg", "--configure", "-a")
-		if out, err := dpkgCmd.CombinedOutput(); err != nil {
-			fmt.Println("Failed to dpkg configure all:")
-			fmt.Println(string(out))
-		}
-		toInstall := &apt.Package{Name: "network-manager"}
-		if out, err := apt.Install(toInstall); err != nil {
-			fmt.Println("Failed to install network-manager:")
-			fmt.Println(string(out))
-			return
-		}
-		cmd := exec.Command("/etc/init.d/network-manager", "start")
-		if out, err := cmd.CombinedOutput(); err != nil {
-			fmt.Println("Failed to start network-manager:")
-			fmt.Println(string(out))
-		}
 
+	dpkgCmd := exec.Command("dpkg", "--configure", "-a")
+	if out, err := dpkgCmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to dpkg configure all:")
+		fmt.Println(string(out))
+	}
+
+	toInstall := &apt.Package{Name: "network-manager"}
+	if out, err := apt.Install(toInstall); err != nil {
+		fmt.Println("Failed to install network-manager:")
+		fmt.Println(string(out))
+		return
+	}
+	cmd := exec.Command("/etc/init.d/network-manager", "start")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		fmt.Println("Failed to start network-manager:")
+		fmt.Println(string(out))
 	}
 }
 

--- a/install.go
+++ b/install.go
@@ -35,7 +35,6 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -66,15 +65,6 @@ func createConfigFolder() error {
 	}
 
 	return nil
-}
-
-func isDockerInstalled() (bool, error) {
-	_, err := exec.LookPath("docker")
-	if err == nil {
-		return true, nil
-	}
-
-	return false, nil
 }
 
 // Register creates the necessary certificates and configuration files

--- a/install.go
+++ b/install.go
@@ -35,6 +35,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -65,6 +66,15 @@ func createConfigFolder() error {
 	}
 
 	return nil
+}
+
+func isDockerInstalled() (bool, error) {
+	_, err := exec.LookPath("docker")
+	if err == nil {
+		return true, nil
+	}
+
+	return false, nil
 }
 
 // Register creates the necessary certificates and configuration files

--- a/install.go
+++ b/install.go
@@ -150,7 +150,7 @@ func registerDeviceViaMQTT(config Config) {
 	err = registerDevice(client, config.ID)
 	check(err, "RegisterDevice")
 
-	client.Disconnect(0)
+	client.Disconnect(100)
 	fmt.Println("MQTT connection successful")
 
 }

--- a/install_test.go
+++ b/install_test.go
@@ -1,10 +1,41 @@
+// +build register
+
 package main
 
 import (
+	"bytes"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
+	"github.com/arduino/arduino-connector/auth"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+)
+
+const (
+	ID           = "arduino-connector-test"
+	AuthClientID = "test-1234567890"
+	DeviceCode   = "device-1234567890"
+	AccessToken  = "test-token"
+	CertPath     = "test-certs"
+	URL          = "localhost"
 )
 
 func TestCheckCreateConfig(t *testing.T) {
@@ -15,4 +46,319 @@ func TestCheckCreateConfig(t *testing.T) {
 	}()
 	_, err = os.Stat("/etc/arduino-connector")
 	assert.True(t, err == nil)
+}
+
+func TestRegister(t *testing.T) {
+
+	// mock the OAuth server
+	oauthTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/oauth/device/code" {
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("content-type"))
+
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(t, "client_id="+AuthClientID+"&audience=https://api.arduino.cc", string(body))
+
+			dc := auth.DeviceCode{
+				DeviceCode:              DeviceCode,
+				UserCode:                "",
+				VerificationURI:         "",
+				ExpiresIn:               0,
+				Interval:                0,
+				VerificationURIComplete: "http://test-verification-uri.com",
+			}
+			data, err := json.Marshal(dc)
+			assert.NoError(t, err)
+
+			w.Write(data)
+		} else if r.URL.Path == "/oauth/token" {
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			assert.Equal(t, "application/x-www-form-urlencoded", r.Header.Get("content-type"))
+
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err)
+			assert.Equal(
+				t,
+				"grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Adevice_code&device_code="+DeviceCode+"&client_id="+AuthClientID,
+				string(body),
+			)
+
+			token := struct {
+				AccessToken string `json:"access_token"`
+				ExpiresIn   int    `json:"expires_in"`
+				TokenType   string `json:"token_type"`
+			}{
+				AccessToken: AccessToken,
+				ExpiresIn:   0,
+				TokenType:   "",
+			}
+			data, err := json.Marshal(token)
+			assert.NoError(t, err)
+
+			w.Write(data)
+		} else {
+			t.Fatalf("unexpected path for oauth test server: %s", r.URL.Path)
+		}
+	}))
+	defer oauthTestServer.Close()
+
+	// mock the AWS API server
+	awsApiTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/iot/v1/devices/connect" {
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			assert.Equal(t, "Bearer "+AccessToken, r.Header.Get("Authorization"))
+
+			resp := struct {
+				URL string `json:"url"`
+			}{
+				URL: URL,
+			}
+			data, err := json.Marshal(resp)
+			assert.NoError(t, err)
+
+			w.Write(data)
+		} else if strings.HasPrefix(r.URL.Path, "/iot/v1/devices/") {
+			assert.Equal(t, "/iot/v1/devices/"+ID, r.URL.Path)
+
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			assert.Equal(t, "Bearer "+AccessToken, r.Header.Get("Authorization"))
+
+			body, err := ioutil.ReadAll(r.Body)
+			assert.NoError(t, err)
+
+			payload := string(body)
+			payload = strings.Replace(payload, "\\n", "\n", -1)
+
+			csr := []byte(strings.TrimSuffix(strings.TrimPrefix(payload, `{"csr":"`), `"}`))
+
+			pemBlock, _ := pem.Decode(csr)
+			assert.NotNil(t, pemBlock)
+
+			clientCsr, err := x509.ParseCertificateRequest(pemBlock.Bytes)
+			assert.NoError(t, err)
+
+			assert.NoError(t, clientCsr.CheckSignature())
+
+			checkCsrRawSubject(t, clientCsr)
+
+			clientCrt, err := crsToCrt(
+				filepath.Join(CertPath, "test-ca.crt"),
+				filepath.Join(CertPath, "test-ca.key"),
+				clientCsr,
+			)
+			assert.NoError(t, err, "error while generating client certificate from certificate signing request")
+			assert.NotNil(t, clientCrt, "generate client certificate is empty")
+
+			resp := struct {
+				Certificate string `json:"certificate"`
+			}{
+				Certificate: string(clientCrt),
+			}
+			data, err := json.Marshal(resp)
+			assert.NoError(t, err)
+
+			w.Write(data)
+		} else {
+			t.Fatalf("unexpected path for aws api test server: %s", r.URL.Path)
+		}
+	}))
+	defer awsApiTestServer.Close()
+
+	// instantiate an observer client to read messages published by arduino-connector
+	client, err := connectTestClient(
+		filepath.Join(CertPath, "test-client.crt"),
+		filepath.Join(CertPath, "test-client.key"),
+	)
+	assert.NoError(t, err)
+
+	// subscribe to register topic and wait for a message
+	var wg sync.WaitGroup
+	wg.Add(1)
+	client.Subscribe("$aws/things/"+ID+"/register", 1, func(client mqtt.Client, msg mqtt.Message) {
+		defer wg.Done()
+
+		var data struct {
+			Host string
+			MACs []string
+		}
+
+		err := json.Unmarshal(msg.Payload(), &data)
+		assert.NoError(t, err)
+
+		host, err := os.Hostname()
+		assert.NoError(t, err)
+
+		macs, err := getMACs()
+		assert.NoError(t, err)
+
+		assert.Equal(t, host, data.Host)
+		assert.Equal(t, macs, data.MACs)
+	})
+
+	defer client.Disconnect(100)
+
+	// call register function to test it
+	testConfig := Config{
+		ID:           ID,
+		AuthURL:      oauthTestServer.URL,
+		AuthClientID: AuthClientID,
+		APIURL:       awsApiTestServer.URL,
+		CertPath:     CertPath,
+	}
+
+	register(testConfig, "config.test", "")
+
+	// check generated config
+	buf, err := ioutil.ReadFile("config.test")
+	assert.NoError(t, err)
+
+	config := strings.Replace(string(buf), "\r\n", "\n", -1)
+	expectedConfig := fmt.Sprintf(`id=%s
+url=%s
+http_proxy=
+https_proxy=
+all_proxy=
+authurl=%s
+auth_client_id=%s
+apiurl=%s
+cert_path=%s
+sketches_path=
+check_ro_fs=false
+env_vars_to_load=
+`, ID, URL, oauthTestServer.URL, AuthClientID, awsApiTestServer.URL, CertPath)
+
+	assert.Equal(t, expectedConfig, config)
+
+	// wait for mqtt test client callback to verify device register info
+	wg.Wait()
+}
+
+func checkCsrRawSubject(t *testing.T, csr *x509.CertificateRequest) {
+	var rdnSeq pkix.RDNSequence
+	rest, err := asn1.Unmarshal(csr.RawSubject, &rdnSeq)
+	assert.NoError(t, err)
+	assert.Len(t, rest, 0)
+
+	var subj pkix.Name
+	subj.FillFromRDNSequence(&rdnSeq)
+
+	assert.Len(t, subj.Country, 1)
+	assert.Equal(t, "IT", subj.Country[0])
+
+	assert.Len(t, subj.Organization, 1)
+	assert.Equal(t, "Arduino AG", subj.Organization[0])
+
+	assert.Len(t, subj.OrganizationalUnit, 1)
+	assert.Equal(t, "Cloud", subj.OrganizationalUnit[0])
+
+	assert.Len(t, subj.Province, 1)
+	assert.Equal(t, "Piemonte", subj.Province[0])
+
+	assert.Len(t, subj.Locality, 1)
+	assert.Equal(t, "Torino", subj.Locality[0])
+
+	assert.Equal(t, ID, subj.CommonName)
+
+	objIds := make(map[string]string)
+	for _, oid := range subj.Names {
+		objIds[oid.Type.String()] = oid.Value.(string)
+	}
+	oidEmailKey := asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 1}.String()
+	assert.Contains(t, objIds, oidEmailKey)
+	assert.Equal(t, ID+"@arduino.cc", objIds[oidEmailKey])
+}
+
+func crsToCrt(caCrtPath, caKeyPath string, csr *x509.CertificateRequest) ([]byte, error) {
+	// load CA certificate and key
+	caCrtFile, err := ioutil.ReadFile(caCrtPath)
+	if err != nil {
+		return nil, err
+	}
+	pemBlock, _ := pem.Decode(caCrtFile)
+	if pemBlock == nil {
+		return nil, err
+	}
+	caCrt, err := x509.ParseCertificate(pemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	caKeyFile, err := ioutil.ReadFile(caKeyPath)
+	if err != nil {
+		return nil, err
+	}
+	pemBlock, _ = pem.Decode(caKeyFile)
+	if pemBlock == nil {
+		return nil, err
+	}
+
+	caPrivateKey, err := x509.ParsePKCS8PrivateKey(pemBlock.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// create client certificate template
+	clientCrtTemplate := x509.Certificate{
+		Signature:          csr.Signature,
+		SignatureAlgorithm: csr.SignatureAlgorithm,
+
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
+		PublicKey:          csr.PublicKey,
+
+		SerialNumber: big.NewInt(2),
+		Issuer:       caCrt.Subject,
+		Subject:      csr.Subject,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	// create client certificate from template and CA public key
+	clientCRTRaw, err := x509.CreateCertificate(
+		rand.Reader,
+		&clientCrtTemplate,
+		caCrt,
+		csr.PublicKey,
+		caPrivateKey,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	var pemCrt bytes.Buffer
+	pem.Encode(&pemCrt, &pem.Block{Type: "CERTIFICATE", Bytes: clientCRTRaw})
+
+	return pemCrt.Bytes(), nil
+}
+
+func connectTestClient(crtPath, keyPath string) (mqtt.Client, error) {
+	// Read client certificate
+	cer, err := tls.LoadX509KeyPair(crtPath, keyPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "test-client read certificate")
+	}
+
+	opts := mqtt.NewClientOptions()
+	opts.SetClientID("test-client")
+	opts.SetMaxReconnectInterval(20 * time.Second)
+	opts.SetConnectTimeout(30 * time.Second)
+	opts.SetAutoReconnect(true)
+	opts.SetTLSConfig(&tls.Config{
+		Certificates: []tls.Certificate{cer},
+		ServerName:   "localhost",
+	})
+	opts.AddBroker("tcps://localhost:8883/mqtt")
+
+	mqttClient := mqtt.NewClient(opts)
+	if token := mqttClient.Connect(); token.Wait() && token.Error() != nil {
+		return nil, errors.Wrap(token.Error(), "test-client connection to broker")
+	}
+
+	return mqttClient, nil
 }

--- a/install_test.go
+++ b/install_test.go
@@ -38,7 +38,7 @@ const (
 	URL          = "localhost"
 )
 
-func TestCheckCreateConfig(t *testing.T) {
+func TestInstallCheckCreateConfig(t *testing.T) {
 	err := createConfigFolder()
 	assert.True(t, err == nil)
 	defer func() {
@@ -48,7 +48,7 @@ func TestCheckCreateConfig(t *testing.T) {
 	assert.True(t, err == nil)
 }
 
-func TestRegister(t *testing.T) {
+func TestInstallRegister(t *testing.T) {
 
 	// mock the OAuth server
 	oauthTestServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/install_test.go
+++ b/install_test.go
@@ -362,3 +362,10 @@ func connectTestClient(crtPath, keyPath string) (mqtt.Client, error) {
 
 	return mqttClient, nil
 }
+
+func TestInstallDocker(t *testing.T) {
+	checkAndInstallDocker()
+	installed, err := isDockerInstalled()
+	assert.True(t, err == nil)
+	assert.True(t, installed)
+}

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+trap 'kill "$(pidof mosquitto)"; rm -rf mosquitto.conf test-certs/ 2> /dev/null' EXIT
+
+mkdir -p test-certs
+
+# create a test Certification Authority
+openssl req \
+    -new \
+    -newkey ec:<(openssl ecparam -name prime256v1) \
+    -days 7 \
+    -nodes \
+    -x509 \
+    -subj "/C=IT/ST=Piemonte/L=Torino/O=TestCA/CN=CA" \
+    -keyout test-certs/test-ca.key \
+    -out test-certs/test-ca.crt
+
+# install the CA
+chmod 0644 test-certs/test-ca.crt
+cp test-certs/test-ca.crt /usr/local/share/ca-certificates/
+update-ca-certificates
+
+# create server certificate
+openssl req \
+    -new \
+    -newkey ec:<(openssl ecparam -name prime256v1) \
+    -nodes \
+    -keyout test-certs/test-server.key \
+    -out test-certs/test-server.csr \
+    -subj "/C=IT/ST=Piemonte/L=Torino/O=TestServer/CN=localhost"
+
+openssl x509 \
+    -req \
+    -in test-certs/test-server.csr \
+    -CA test-certs/test-ca.crt \
+    -CAkey test-certs/test-ca.key \
+    -CAcreateserial \
+    -out test-certs/test-server.crt \
+    -days 7 \
+    -sha256
+
+# create client certificate
+openssl req \
+    -new \
+    -newkey ec:<(openssl ecparam -name prime256v1) \
+    -nodes \
+    -keyout test-certs/test-client.key \
+    -out test-certs/test-client.csr \
+    -subj "/C=IT/ST=Piemonte/L=Torino/O=TestServer/CN=localhost"
+
+openssl x509 \
+    -req \
+    -in test-certs/test-client.csr \
+    -CA test-certs/test-ca.crt \
+    -CAkey test-certs/test-ca.key \
+    -CAcreateserial \
+    -out test-certs/test-client.crt \
+    -days 7 \
+    -sha256
+
+# generate mosquitto config to use client certificates
+echo \
+"port 8883
+require_certificate true
+cafile ./test-certs/test-ca.crt
+keyfile ./test-certs/test-server.key
+certfile ./test-certs/test-server.crt
+log_dest none" \
+> mosquitto.conf
+
+mosquitto -c mosquitto.conf > /dev/null &
+
+# see https://github.com/golang/go/issues/39568 about why we need to set that GODEBUG value
+GODEBUG=x509ignoreCN=0 go test -v --tags=register --run="TestRegister" --timeout=15s

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -73,4 +73,4 @@ log_dest none" \
 mosquitto -c mosquitto.conf > /dev/null &
 
 # see https://github.com/golang/go/issues/39568 about why we need to set that GODEBUG value
-GODEBUG=x509ignoreCN=0 go test -v --tags=register --run="TestRegister" --timeout=15s
+GODEBUG=x509ignoreCN=0 go test -v --tags=register --run="TestInstall" --timeout=15s

--- a/scripts/install-tests.sh
+++ b/scripts/install-tests.sh
@@ -73,4 +73,4 @@ log_dest none" \
 mosquitto -c mosquitto.conf > /dev/null &
 
 # see https://github.com/golang/go/issues/39568 about why we need to set that GODEBUG value
-GODEBUG=x509ignoreCN=0 go test -v --tags=register --run="TestInstall" --timeout=15s
+GODEBUG=x509ignoreCN=0 go test -v --tags=register --run="TestInstall" --timeout=100s


### PR DESCRIPTION
The purpose of this PR is to introduce some tests to verify the registering and installation process of `arduino-connector`, without interacting with the real AWS API endpoints.

Regarding the `TestRegister` test, the following approach is used:
- create and install a custom _Certificate Authority_
- generate a server certificate for `mosquitto`
- generate a client certificate to subscribe to `mosquitto` and check what `arduino-connector` is publishing
- configure `mosquitto` to reject unauthenticated connections
- mock the _OAuth_ server to be able to verify the token-based authentication flow
- mock the _AWS_ API servers, to be able to check the _Certificate Signing Request_ and send back a certificate built for this test
- run the `register` function
- check that `arduino-connector` is:
  - connecting to the broker using the generated certificate
  - publishing the correct information to the `/register` topic