### PR TITLE
Config folder

### DIFF
--- a/arduino-connector.sh
+++ b/arduino-connector.sh
@@ -58,7 +58,8 @@ echo ---------
 
 echo remove old files
 echo ---------
-sudo rm -f /usr/bin/arduino-connector* /usr/bin/certificate*
+sudo rm -f /usr/bin/arduino-connector*
+sudo rm -rf /etc/arduino-connector
 
 echo uninstall previous installations of connector
 echo ---------

--- a/install.go
+++ b/install.go
@@ -58,6 +58,15 @@ func install(s service.Service) {
 	check(err, "InstallService")
 }
 
+func createConfigFolder() error {
+	err := os.Mkdir("/etc/arduino-connector/", 0755)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // Register creates the necessary certificates and configuration files
 func register(config Config, configFile, token string) {
 	// Request token

--- a/install_test.go
+++ b/install_test.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCheckCreateConfig(t *testing.T) {
+	err := createConfigFolder()
+	assert.True(t, err == nil)
+	defer func() {
+		os.RemoveAll("/etc/arduino-connector")
+	}()
+	_, err = os.Stat("/etc/arduino-connector")
+	assert.True(t, err == nil)
+}

--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func main() {
 	}
 
 	if *doRegister {
+		createConfigFolder()
 		register(config, *configFile, *token)
 	}
 

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 )
 
 const (
-	defaultConfigFile = "/usr/bin/arduino-connector.cfg"
+	defaultConfigFile = "/etc/arduino-connector/arduino-connector.cfg"
 )
 
 var (
@@ -103,7 +103,7 @@ func main() {
 	flag.StringVar(&config.appName, "appName", "arduino-connector", "")
 
 	var configFile = flag.String(flag.DefaultConfigFlagname, "", "path to config file")
-	flag.StringVar(&config.CertPath, "cert_path", "/usr/bin/", "path to store certificates")
+	flag.StringVar(&config.CertPath, "cert_path", "/etc/arduino-connector/", "path to store certificates")
 	flag.StringVar(&config.SketchesPath, "sketches_path", "", "path to store sketches")
 	flag.StringVar(&config.ID, "id", "", "id of the thing in aws iot")
 	flag.StringVar(&config.URL, "url", "", "url of the thing in aws iot")
@@ -151,7 +151,10 @@ func main() {
 	}
 
 	if *doRegister {
-		createConfigFolder()
+		err = createConfigFolder()
+		if err != nil {
+			panic(err)
+		}
 		register(config, *configFile, *token)
 	}
 

--- a/scripts/arduino-connector-dev.sh
+++ b/scripts/arduino-connector-dev.sh
@@ -48,7 +48,8 @@ echo ---------
 
 echo remove old files
 echo ---------
-rm -f arduino-connector* certificate*
+sudo rm -f /usr/bin/arduino-connector*
+sudo rm -rf /etc/arduino-connector
 
 echo uninstall previous installations of connector
 echo ---------


### PR DESCRIPTION
With this PR arduino-connector during the installation process creates a folder in `/etc/` for configuration such as .cfg and certs because now all files are installed in `/usr/bin`.